### PR TITLE
v0.6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+.lock-wscript

--- a/package.json
+++ b/package.json
@@ -1,33 +1,41 @@
 {
-   "name": "video",
-   "version": "1.0.3",
-   "main": "video",
-   "description": "A C++ module for node.js that creates Theora/Ogg videos from RGB frames.",
-   "keywords": [
-       "video",
-       "videos",
-       "theora",
-       "rgb"
-   ],
-   "author": {
-       "name": "Peteris Krumins",
-       "email": "peteris.krumins@gmail.com",
-       "web": "http://www.catonmat.net",
-       "twitter": "pkrumins"
-   }, 
-   "license": "MIT",
-   "repository": {
-       "type": "git",
-       "url": "http://github.com/pkrumins/node-video.git" 
-   }, 
-   "directories": {
-       "tests": "tests"
-   },
-   "engines": {
-       "node": ">=0.1.93"
-   },
-   "scripts": {
-       "install": "node-waf configure build"
-   }
+  "name": "video",
+    "version": "1.0.4",
+    "main": "build/Release/video.node",
+    "description": "A C++ module for node.js that creates Theora/Ogg videos from RGB frames.",
+    "keywords": [
+      "video",
+    "videos",
+    "theora",
+    "rgb"
+      ],
+    "maintainers": [
+    {
+      "name": "Peteris Krumins",
+      "email": "peteris.krumins@gmail.com",
+      "web": "http://www.catonmat.net",
+      "twitter": "pkrumins"
+    } 
+  ],
+    "licenses": [
+    {
+      "type": "MIT"
+    } 
+  ],
+    "repositories": [
+    {
+      "type": "git",
+      "url": "http://github.com/pkrumins/node-video.git" 
+    } 
+  ],
+    "directories": {
+      "tests": "tests"
+    },
+    "engines": {
+      "node": ">=0.1.93 <=v0.6.12"
+    },
+    "scripts": {
+      "install": "node-waf configure build"
+    }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+
 This is a node.js module, writen in C++, that produces Theora/Ogg videos from
 the given RGB buffers.
 
@@ -15,9 +16,7 @@ This module exports several objects that you can work with:
     // these are not there yet, still hacking them in right now.
     // * StreamingVideo - to create streamable videos (works with HTML5 <video>)
 
-
-FixedVideo
-----------
+##FixedVideo
 
 FixedVideo object is for creating videos from fixed size frames. That is,
 each frame is exactly the same size, for example, each frame is 720x400 pixels.
@@ -73,8 +72,7 @@ to garbage collector. If `video` goes out of scope, it also closes the video
 file and frees all resources.
 
 
-StackedVideo
-------------
+##StackedVideo
 
 StackedVideo object is for stacking many small frame updates together and then
 encoding the frame as a whole. Here is how it works. The first frame sent to
@@ -137,8 +135,7 @@ That will close all the file handles and free memory. Alternatively you can let
 the `stackedVideo` object go out of scope, which will have the same effect.
 
 
-AsyncStackedVideo
------------------
+##AsyncStackedVideo
 
 AsyncStackedVideo is the same as StackedVideo except it's asynchronous.
 
@@ -166,14 +163,12 @@ callback function, which will be called once the encoding is done:
     });
 
 
-StreamingVideo
---------------
+##StreamingVideo
 
 Also coming near you soon. This is the most awesome stuff!
 
 
-How to compile?
----------------
+##How to compile?
 
 You need node.js installed to compile this module. When installed it comes with
 node-waf tool, run it in this libs dir:
@@ -183,9 +178,11 @@ node-waf tool, run it in this libs dir:
 This will produce video.node dll. After that, make sure NODE_PATH contains lib's
 dir. 
 
+## Installation
 
-Other stuff in this module
---------------------------
+    npm install node-video [-g]
+
+##Other stuff in this module
 
 The discovery/ directory contains all the snippets I wrote to understand how
 to get video working. It's a habit of effective hackers to try lots of small
@@ -207,3 +204,7 @@ Sincerely,
 Peteris Krumins
 http://www.catonmat.net
 
+## Contributors
+
+* Node v0.3 buffers (James Halliday substack)
+* Node v0.6 compatibility (Pascal Deschenes <pdeschen at gmail dot com>)

--- a/src/async_stacked_video.h
+++ b/src/async_stacked_video.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <node.h>
+#include <node_version.h>
 #include "video_encoder.h"
 
 struct push_request {
@@ -38,10 +39,14 @@ class AsyncStackedVideo : public node::ObjectWrap {
     std::string tmp_dir;
     unsigned int push_id, fragment_id;
 
+#if NODE_VERSION_AT_LEAST(0,6,0)
+    static void EIO_Push(eio_req *req);
+    static void EIO_Encode(eio_req *req);
+#else
     static int EIO_Push(eio_req *req);
-    static int EIO_PushAfter(eio_req *req);
-
     static int EIO_Encode(eio_req *req);
+#endif
+    static int EIO_PushAfter(eio_req *req);
     static int EIO_EncodeAfter(eio_req *req);
 
     static void push_fragment(unsigned char *frame, int width, int height,

--- a/src/fixed_video.cpp
+++ b/src/fixed_video.cpp
@@ -1,4 +1,5 @@
 #include <node_buffer.h>
+#include <node_version.h>
 #include "common.h"
 #include "fixed_video.h"
 
@@ -95,11 +96,18 @@ FixedVideo::NewFrame(const Arguments &args)
 
     if (!Buffer::HasInstance(args[0])) 
         return VException("First argument must be Buffer.");
-
+#if NODE_VERSION_AT_LEAST(0,3,0)
+    v8::Handle<v8::Object> rgb = args[0]->ToObject();
+#else
     Buffer *rgb = ObjectWrap::Unwrap<Buffer>(args[0]->ToObject());
+#endif
 
     FixedVideo *fv = ObjectWrap::Unwrap<FixedVideo>(args.This());
+#if NODE_VERSION_AT_LEAST(0,3,0)
+    fv->NewFrame((unsigned char *) Buffer::Data(rgb));
+#else
     fv->NewFrame((unsigned char *)rgb->data());
+#endif
 
     return Undefined();
 }

--- a/src/stacked_video.cpp
+++ b/src/stacked_video.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <node_buffer.h>
+#include <node_version.h>
 #include "common.h"
 #include "stacked_video.h"
 
@@ -190,10 +191,19 @@ StackedVideo::NewFrame(const Arguments &args)
             return VException("Timestamp can't be negative.");
     }
 
+#if NODE_VERSION_AT_LEAST(0,3,0)
+    v8::Handle<v8::Object> rgb = args[0]->ToObject();
+#else
     Buffer *rgb = ObjectWrap::Unwrap<Buffer>(args[0]->ToObject());
+#endif
 
     StackedVideo *sv = ObjectWrap::Unwrap<StackedVideo>(args.This());
+
+#if NODE_VERSION_AT_LEAST(0,3,0)
+    sv->NewFrame((unsigned char *) Buffer::Data(rgb), timeStamp);
+#else
     sv->NewFrame((unsigned char *)rgb->data(), timeStamp);
+#endif
 
     return Undefined();
 }
@@ -218,7 +228,11 @@ StackedVideo::Push(const Arguments &args)
         return VException("Fifth argument must be integer height.");
 
     StackedVideo *sv = ObjectWrap::Unwrap<StackedVideo>(args.This());
+#if NODE_VERSION_AT_LEAST(0,3,0)
+    v8::Handle<v8::Object> rgb = args[0]->ToObject();
+#else
     Buffer *rgb = ObjectWrap::Unwrap<Buffer>(args[0]->ToObject());
+#endif
     int x = args[1]->Int32Value();
     int y = args[2]->Int32Value();
     int w = args[3]->Int32Value();
@@ -241,7 +255,11 @@ StackedVideo::Push(const Arguments &args)
     if (y+h > sv->height) 
         return VException("Pushed buffer exceeds StackedVideo's height.");
 
+#if NODE_VERSION_AT_LEAST(0,3,0)
+    sv->Push((unsigned char *) Buffer::Data(rgb), x, y, w, h);
+#else
     sv->Push((unsigned char *)rgb->data(), x, y, w, h);
+#endif
 
     return Undefined();
 }


### PR DESCRIPTION
Hi,
This pull request includes year old patch from James Halliday (substack) for v0.3 buffer support along with my own fix for v0.6 support. I've bump the version number and tag the version (v1.0.4), fix the package.json node version requirement along with a few minor modify within the readme. Well, check the commit history :-)

Cheers!
